### PR TITLE
Fix no-undef Not Working

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
 module.exports = {
+  env: {
+    "es6": true,
+  },
   extends: [
     'eslint:recommended',
   ],

--- a/jsx-control-statements.js
+++ b/jsx-control-statements.js
@@ -10,7 +10,8 @@ module.exports = {
     'jsx-control-statements/jsx-otherwise-once-last': 1,
     'jsx-control-statements/jsx-use-if-tag': 1,
     'jsx-control-statements/jsx-when-require-condition': 1,
-    'jsx-control-statements/jsx-jcs-no-undef': 0
+    'jsx-control-statements/jsx-jcs-no-undef': 2,
+    'react/jsx-no-undef': [2, { 'allowGlobals': true }],
   },
   extends: [
     'plugin:jsx-control-statements/recommended',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glints/eslint-config",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "ESLint rules for Glints projects.",
   "keywords": [
     "eslint",


### PR DESCRIPTION
Extending `jsx-control-statements/recommended` disabled the vanilla eslint no-undef rule which resulted in the users of this config not seeing errors for undefined variables. To fix this, his PR enables a special `no-undef` rule that also knows how to deal with jsx-control-statements.