### PR TITLE
Travis: Do not build from a pull request if the PR updates the tag.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   - node
 
-if: tag IS present
+if: tag IS present AND $TRAVIS_EVENT_TYPE != 'pull_request' AND branch = master
 
 script: "true"
 


### PR DESCRIPTION
When a PR is made from a branch in the repo itself (not a fork),
there are two possibilities from where a build can be triggered.
The first possibility is at the time when a commit is pushed to
a branch `feature/x` on the repo. To make sure that we don't
trigger a build in this case, we check if `branch = master`.
Now, another possibilty of a trigger can be when a PR from
`feature/x` is made into master, but this time around
`branch = master` check may not suffice since in case of PRs
the branch is the target branch, to tackle this we add an
additional check `$TRAVIS_EVENT_TYPE != 'pull_request'`