### PR TITLE
Remove react/no-set-state rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glints/eslint-config",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "ESLint rules for Glints projects.",
   "keywords": [
     "eslint",

--- a/react.js
+++ b/react.js
@@ -7,7 +7,6 @@ module.exports = {
     'react/no-did-update-set-state': 'error',
     'react/no-direct-mutation-state': 'error',
     'react/no-is-mounted': 'error',
-    'react/no-set-state': 'error',
     'react/no-string-refs': 'error',
     'react/no-unknown-property': 'warn',
     'react/prefer-es6-class': 'warn',


### PR DESCRIPTION
This rule was being used to enforce a certain coding style which is now obsolete.

https://glints.slack.com/archives/C956ZDAP7/p1585618076096700